### PR TITLE
Decode storyboard resources: named colors and images

### DIFF
--- a/Sources/Models/Documents/StoryboardDocument.swift
+++ b/Sources/Models/Documents/StoryboardDocument.swift
@@ -23,6 +23,7 @@ public struct StoryboardDocument: XMLDecodable {
     public let device: Device?
     public let scenes: [Scene]?
     public let placeholders: [Placeholder]?
+    public let resources: [AnyResource]?
 
     static func decode(_ xml: XMLIndexer) throws -> StoryboardDocument {
         return StoryboardDocument.init(
@@ -38,7 +39,8 @@ public struct StoryboardDocument: XMLDecodable {
             initialViewController: xml.attributeValue(of: "initialViewController"),
             device:                xml.byKey("device").flatMap(decodeValue),
             scenes:                xml.byKey("scenes")?.byKey("scene")?.all.flatMap(decodeValue),
-            placeholders:          xml.byKey("objects")?.byKey("placeholder")?.all.flatMap(decodeValue)
+            placeholders:          xml.byKey("objects")?.byKey("placeholder")?.all.flatMap(decodeValue),
+            resources:             xml.byKey("resources")?.children.flatMap(decodeValue)
         )
     }
 }

--- a/Sources/Models/Files/StoryboardFile.swift
+++ b/Sources/Models/Files/StoryboardFile.swift
@@ -19,9 +19,21 @@ public class StoryboardFile: InterfaceBuilderFile {
         self.document = try type(of: self).parseContent(pathString: path)
     }
 
+    public init(url: URL) throws {
+        self.pathString = url.absoluteString
+        self.document = try type(of: self).parseContent(url: url)
+    }
+
     private static func parseContent(pathString: String) throws -> StoryboardDocument {
         let parser = InterfaceBuilderParser()
         let content = try String.init(contentsOfFile: pathString)
         return try parser.parseStoryboard(xml: content)
     }
+
+    private static func parseContent(url: URL) throws -> StoryboardDocument {
+        let parser = InterfaceBuilderParser()
+        let content = try String.init(contentsOf: url)
+        return try parser.parseStoryboard(xml: content)
+    }
+
 }

--- a/Sources/Models/Files/XibFile.swift
+++ b/Sources/Models/Files/XibFile.swift
@@ -19,9 +19,20 @@ public class XibFile: InterfaceBuilderFile {
         self.document = try type(of: self).parseContent(pathString: path)
     }
 
+    public init(url: URL) throws {
+        self.pathString = url.absoluteString
+        self.document = try type(of: self).parseContent(url: url)
+    }
+
     private static func parseContent(pathString: String) throws -> XibDocument {
         let parser = InterfaceBuilderParser()
         let content = try String.init(contentsOfFile: pathString)
+        return try parser.parseXib(xml: content)
+    }
+
+    private static func parseContent(url: URL) throws -> XibDocument {
+        let parser = InterfaceBuilderParser()
+        let content = try String.init(contentsOf: url)
         return try parser.parseXib(xml: content)
     }
 }

--- a/Sources/Models/Resources/AnyResource.swift
+++ b/Sources/Models/Resources/AnyResource.swift
@@ -1,0 +1,38 @@
+//
+//  AnyResources.swift
+//  Tests
+//
+//  Created by phimage on 01/04/2018.
+//
+
+import SWXMLHash
+
+// MARK: - ResourceProtocol
+
+public protocol ResourceProtocol {
+    var name: String { get }
+}
+
+// MARK: - AnyResource
+
+public struct AnyResource: XMLDecodable {
+
+    public let resource: ResourceProtocol
+
+    init(_ resource: ResourceProtocol) {
+        self.resource = resource
+    }
+
+    static func decode(_ xml: XMLIndexer) throws -> AnyResource {
+        guard let elementName = xml.element?.name else {
+            throw IBError.elementNotFound
+        }
+        switch elementName {
+        case "namedColor":      return try AnyResource(NamedColor.decode(xml))
+        case "image":           return try AnyResource(Image.decode(xml))
+        default:
+            throw IBError.unsupportedViewClass(elementName)
+        }
+    }
+
+}

--- a/Sources/Models/Resources/Image.swift
+++ b/Sources/Models/Resources/Image.swift
@@ -1,0 +1,21 @@
+//
+//  Image.swift
+//  IBDecodable
+//
+//  Created by phimage on 01/04/2018.
+//
+
+import SWXMLHash
+
+public struct Image: XMLDecodable, ResourceProtocol {
+    public let name: String
+    public let width: String
+    public let height: String
+    
+    static func decode(_ xml: XMLIndexer) throws -> Image {
+        return Image.init(
+            name:      try xml.attributeValue(of: "name"),
+            width:     try xml.attributeValue(of: "width"),
+            height:    try xml.attributeValue(of: "height"))
+    }
+}

--- a/Sources/Models/Resources/NamedColor.swift
+++ b/Sources/Models/Resources/NamedColor.swift
@@ -1,0 +1,20 @@
+//
+//  NamedColor.swift
+//  Tests
+//
+//  Created by phimage on 01/04/2018.
+//
+
+import SWXMLHash
+
+public struct NamedColor: XMLDecodable, ResourceProtocol {
+    public let name: String
+    public let color: Color?
+
+    static func decode(_ xml: XMLIndexer) throws -> NamedColor {
+        return NamedColor.init(
+            name:    try xml.attributeValue(of: "name"),
+            color:   xml.byKey("color").flatMap(decodeValue))
+    }
+
+}

--- a/Tests/Launch Screen.xml
+++ b/Tests/Launch Screen.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="obG-Y5-kRd">
+                                <rect key="frame" x="0.0" y="626.5" width="375" height="20.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="IBDecodable" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="GJd-Yh-RWb">
+                                <rect key="frame" x="0.0" y="202" width="375" height="43"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="36"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="Bcu-3y-fUS" firstAttribute="centerX" secondItem="obG-Y5-kRd" secondAttribute="centerX" id="5cz-MP-9tL"/>
+                            <constraint firstItem="Bcu-3y-fUS" firstAttribute="centerX" secondItem="GJd-Yh-RWb" secondAttribute="centerX" id="Q3B-4B-g5h"/>
+                            <constraint firstItem="obG-Y5-kRd" firstAttribute="leading" secondItem="Bcu-3y-fUS" secondAttribute="leading" constant="20" symbolic="YES" id="SfN-ll-jLj"/>
+                            <constraint firstAttribute="bottom" secondItem="obG-Y5-kRd" secondAttribute="bottom" constant="20" id="Y44-ml-fuU"/>
+                            <constraint firstItem="GJd-Yh-RWb" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="bottom" multiplier="1/3" constant="1" id="moa-c2-u7t"/>
+                            <constraint firstItem="GJd-Yh-RWb" firstAttribute="leading" secondItem="Bcu-3y-fUS" secondAttribute="leading" constant="20" symbolic="YES" id="x7j-FC-K8j"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="Bcu-3y-fUS"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Tests/Media.xcassets/Color.colorset/Contents.json
+++ b/Tests/Media.xcassets/Color.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "1.000",
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000"
+        }
+      }
+    }
+  ]
+}

--- a/Tests/Media.xcassets/Contents.json
+++ b/Tests/Media.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Tests/Storyboard.xml
+++ b/Tests/Storyboard.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+    </dependencies>
+    <scenes/>
+</document>

--- a/Tests/StoryboardAsset.xml
+++ b/Tests/StoryboardAsset.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="x5u-1J-Eih">
+            <objects>
+                <viewController id="GjI-MH-9vq" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ycr-Sg-LUd">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vfs-L9-b1p">
+                                <rect key="frame" x="154" y="216" width="42" height="21"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" name="Color"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="Image" translatesAutoresizingMaskIntoConstraints="NO" id="jg4-Lo-gzV">
+                                <rect key="frame" x="96" y="338" width="115" height="81"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            </imageView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <viewLayoutGuide key="safeArea" id="hhG-XG-10b"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="3UH-mE-rOD" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-44" y="143.47826086956522"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="Image" width="16" height="16"/>
+        <namedColor name="Color">
+            <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
+</document>

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -1,0 +1,78 @@
+//
+//  Tests.swift
+//  Tests
+//
+//  Created by phimage on 31/03/2018.
+//
+
+import XCTest
+@testable import IBDecodable
+
+class Tests: XCTestCase {
+
+    func testEmptyView() {
+        guard let url = Bundle(for: type(of: self)).url(forResource: "View", withExtension: "xml") else {
+            XCTFail("File not found")
+            return
+        }
+        do {
+            let file = try XibFile(url: url)
+            print(file.document.targetRuntime)
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+
+    func testEmptyLaunchScreen() {
+        guard let url = Bundle(for: type(of: self)).url(forResource: "Launch Screen", withExtension: "xml") else {
+            XCTFail("File not found")
+            return
+        }
+        do {
+            let file = try StoryboardFile(url: url)
+            print(file.document.targetRuntime)
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+
+    func testEmptyStoryboard() {
+        guard let url = Bundle(for: type(of: self)).url(forResource: "Storyboard", withExtension: "xml") else {
+            XCTFail("File not found")
+            return
+        }
+        do {
+            let file = try StoryboardFile(url: url)
+            print(file.document.targetRuntime)
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+
+    func testStoryboardWithAsset() {
+        guard let url = Bundle(for: type(of: self)).url(forResource: "StoryboardAsset", withExtension: "xml") else {
+            XCTFail("File not found")
+            return
+        }
+        do {
+            let file = try StoryboardFile(url: url)
+            guard let resources = file.document.resources, !resources.isEmpty else {
+                XCTFail("No asset resources found")
+                return
+            }
+            // Check images
+            let images: [Image] = resources.flatMap { $0.resource as? Image }
+            XCTAssertFalse(images.isEmpty, "There is no image")
+            // Check named colors
+            let namedColor: [NamedColor] =  resources.flatMap { $0.resource as? NamedColor }
+            XCTAssertFalse(namedColor.isEmpty, "There is no named color")
+            namedColor.forEach {
+                XCTAssertNotNil($0.color)
+            }
+            
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+
+}

--- a/Tests/View.xml
+++ b/Tests/View.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+        </view>
+    </objects>
+</document>


### PR DESCRIPTION
Fix parsing of named color in storyboard by adding a new case to `Color`

Add Unit tests, because I cannot code without testing. But I am an IDE guy, I do use "swift test", so feel free to adapt if necessary, it's just a starter

Allow to start parsing using a file URL. Using `URL` is always better for file
I think also `Data` from files must be passed to xml parser avoiding useless conversion to `String`