### PR TITLE
Add swiftlint configuration file. Fix some basic style issues.

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,13 @@
+included:
+- Sources
+line_length:
+  warning: 165
+  ignores_comments: true
+large_tuple:
+  warning: 3
+disabled_rules:
+  - colon
+  - identifier_name
+  - type_name
+  - cyclomatic_complexity
+  - pattern_matching_keywords

--- a/Sources/Models/Controllers/AnyViewController.swift
+++ b/Sources/Models/Controllers/AnyViewController.swift
@@ -58,7 +58,7 @@ public struct ViewControllerLayoutGuide: XMLDecodable {
     public let type: String
 
     static func decode(_ xml: XMLIndexer) throws -> ViewControllerLayoutGuide {
-        return try ViewControllerLayoutGuide.init(
+        return try ViewControllerLayoutGuide(
             id: xml.attributeValue(of: "id"),
             type: xml.attributeValue(of: "type")
         )

--- a/Sources/Models/Controllers/CollectionViewController.swift
+++ b/Sources/Models/Controllers/CollectionViewController.swift
@@ -21,7 +21,7 @@ public struct CollectionViewController: XMLDecodable, ViewControllerProtocol {
     public var rootView: ViewProtocol? { return view }
 
     static func decode(_ xml: XMLIndexer) throws -> CollectionViewController {
-        return CollectionViewController.init(
+        return CollectionViewController(
             id:                   try xml.attributeValue(of: "id"),
             customClass:          xml.attributeValue(of: "customClass"),
             customModule:         xml.attributeValue(of: "customModule"),

--- a/Sources/Models/Controllers/Frameworks/AVPlayerViewController.swift
+++ b/Sources/Models/Controllers/Frameworks/AVPlayerViewController.swift
@@ -21,7 +21,7 @@ public struct AVPlayerViewController: XMLDecodable, ViewControllerProtocol {
     public var rootView: ViewProtocol? { return view?.view }
 
     static func decode(_ xml: XMLIndexer) throws -> AVPlayerViewController {
-        return AVPlayerViewController.init(
+        return AVPlayerViewController(
             id:                   try xml.attributeValue(of: "id"),
             customClass:          xml.attributeValue(of: "customClass"),
             customModule:         xml.attributeValue(of: "customModule"),

--- a/Sources/Models/Controllers/Frameworks/GLKViewController.swift
+++ b/Sources/Models/Controllers/Frameworks/GLKViewController.swift
@@ -21,7 +21,7 @@ public struct GLKViewController: XMLDecodable, ViewControllerProtocol {
     public var rootView: ViewProtocol? { return glkView }
 
     static func decode(_ xml: XMLIndexer) throws -> GLKViewController {
-        return GLKViewController.init(
+        return GLKViewController(
             id:                   try xml.attributeValue(of: "id"),
             customClass:          xml.attributeValue(of: "customClass"),
             customModule:         xml.attributeValue(of: "customModule"),

--- a/Sources/Models/Controllers/NavigationController.swift
+++ b/Sources/Models/Controllers/NavigationController.swift
@@ -19,9 +19,9 @@ public struct NavigationController: XMLDecodable, ViewControllerProtocol {
     public let userDefinedRuntimeAttributes: [UserDefinedRuntimeAttribute]?
     public let navigationBar: NavigationBar?
     public var rootView: ViewProtocol? { return navigationBar }
-    
+
     static func decode(_ xml: XMLIndexer) throws -> NavigationController {
-        return NavigationController.init(
+        return NavigationController(
             id:                   try xml.attributeValue(of: "id"),
             customClass:          xml.attributeValue(of: "customClass"),
             customModule:         xml.attributeValue(of: "customModule"),
@@ -33,4 +33,3 @@ public struct NavigationController: XMLDecodable, ViewControllerProtocol {
         )
     }
 }
-

--- a/Sources/Models/Controllers/PageViewController.swift
+++ b/Sources/Models/Controllers/PageViewController.swift
@@ -21,7 +21,7 @@ public struct PageViewController: XMLDecodable, ViewControllerProtocol {
     public var rootView: ViewProtocol? { return view }
 
     static func decode(_ xml: XMLIndexer) throws -> PageViewController {
-        return PageViewController.init(
+        return PageViewController(
             id:                   try xml.attributeValue(of: "id"),
             customClass:          xml.attributeValue(of: "customClass"),
             customModule:         xml.attributeValue(of: "customModule"),

--- a/Sources/Models/Controllers/SplitViewController.swift
+++ b/Sources/Models/Controllers/SplitViewController.swift
@@ -21,7 +21,7 @@ public struct SplitViewController: XMLDecodable, ViewControllerProtocol {
     public var rootView: ViewProtocol? { return view }
 
     static func decode(_ xml: XMLIndexer) throws -> SplitViewController {
-        return SplitViewController.init(
+        return SplitViewController(
             id:                   try xml.attributeValue(of: "id"),
             customClass:          xml.attributeValue(of: "customClass"),
             customModule:         xml.attributeValue(of: "customModule"),

--- a/Sources/Models/Controllers/TabBarController.swift
+++ b/Sources/Models/Controllers/TabBarController.swift
@@ -21,7 +21,7 @@ public struct TabBarController: XMLDecodable, ViewControllerProtocol {
     public var rootView: ViewProtocol? { return view }
 
     static func decode(_ xml: XMLIndexer) throws -> TabBarController {
-        return TabBarController.init(
+        return TabBarController(
             id:                   try xml.attributeValue(of: "id"),
             customClass:          xml.attributeValue(of: "customClass"),
             customModule:         xml.attributeValue(of: "customModule"),

--- a/Sources/Models/Controllers/TableViewController.swift
+++ b/Sources/Models/Controllers/TableViewController.swift
@@ -21,7 +21,7 @@ public struct TableViewController: XMLDecodable, ViewControllerProtocol {
     public var rootView: ViewProtocol? { return tableView }
 
     static func decode(_ xml: XMLIndexer) throws -> TableViewController {
-        return TableViewController.init(
+        return TableViewController(
             id:                   try xml.attributeValue(of: "id"),
             customClass:          xml.attributeValue(of: "customClass"),
             customModule:         xml.attributeValue(of: "customModule"),

--- a/Sources/Models/Controllers/ViewController.swift
+++ b/Sources/Models/Controllers/ViewController.swift
@@ -21,7 +21,7 @@ public struct ViewController: XMLDecodable, ViewControllerProtocol {
     public var rootView: ViewProtocol? { return view }
 
     static func decode(_ xml: XMLIndexer) throws -> ViewController {
-        return ViewController.init(
+        return ViewController(
             id:                   try xml.attributeValue(of: "id"),
             customClass:          xml.attributeValue(of: "customClass"),
             customModule:         xml.attributeValue(of: "customModule"),

--- a/Sources/Models/Documents/StoryboardDocument.swift
+++ b/Sources/Models/Documents/StoryboardDocument.swift
@@ -27,7 +27,7 @@ public struct StoryboardDocument: XMLDecodable {
     public let resources: [AnyResource]?
 
     static func decode(_ xml: XMLIndexer) throws -> StoryboardDocument {
-        return StoryboardDocument.init(
+        return StoryboardDocument(
             type:                  try xml.attributeValue(of: "type"),
             version:               try xml.attributeValue(of: "version"),
             toolsVersion:          try xml.attributeValue(of: "toolsVersion"),
@@ -55,7 +55,7 @@ public struct Device: XMLDecodable {
     public let adaptation: String?
 
     static func decode(_ xml: XMLIndexer) throws -> Device {
-        return Device.init(
+        return Device(
             id:          try xml.attributeValue(of: "id"),
             orientation: xml.attributeValue(of: "orientation"),
             adaptation:  xml.byKey("adaptation")?.attributeValue(of: "id")
@@ -71,7 +71,7 @@ public struct Scene: XMLDecodable {
     public let canvasLocation: Point?
 
     static func decode(_ xml: XMLIndexer) throws -> Scene {
-        return Scene.init(
+        return Scene(
             id:             try xml.attributeValue(of: "sceneID"),
             viewController: xml.byKey("objects")?.children.first.flatMap(decodeValue),
             canvasLocation: xml.byKey("point").flatMap(decodeValue)
@@ -89,7 +89,7 @@ public struct Placeholder: XMLDecodable {
     public let customClass: String?
 
     static func decode(_ xml: XMLIndexer) throws -> Placeholder {
-        return Placeholder.init(
+        return Placeholder(
             id:                    try xml.attributeValue(of: "id"),
             placeholderIdentifier: try xml.attributeValue(of: "placeholderIdentifier"),
             userLabel:             xml.attributeValue(of: "userLabel"),

--- a/Sources/Models/Documents/XibDocument.swift
+++ b/Sources/Models/Documents/XibDocument.swift
@@ -22,7 +22,7 @@ public struct XibDocument: XMLDecodable {
     public let placeholders: [Placeholder]?
 
     static func decode(_ xml: XMLIndexer) throws -> XibDocument {
-        return XibDocument.init(
+        return XibDocument(
             type:                  try xml.attributeValue(of: "type"),
             version:               try xml.attributeValue(of: "version"),
             toolsVersion:          try xml.attributeValue(of: "toolsVersion"),

--- a/Sources/Models/Files/StoryboardFile.swift
+++ b/Sources/Models/Files/StoryboardFile.swift
@@ -26,13 +26,13 @@ public class StoryboardFile: InterfaceBuilderFile {
 
     private static func parseContent(pathString: String) throws -> StoryboardDocument {
         let parser = InterfaceBuilderParser()
-        let content = try String.init(contentsOfFile: pathString)
+        let content = try String(contentsOfFile: pathString)
         return try parser.parseStoryboard(xml: content)
     }
 
     private static func parseContent(url: URL) throws -> StoryboardDocument {
         let parser = InterfaceBuilderParser()
-        let content = try String.init(contentsOf: url)
+        let content = try String(contentsOf: url)
         return try parser.parseStoryboard(xml: content)
     }
 

--- a/Sources/Models/Files/XibFile.swift
+++ b/Sources/Models/Files/XibFile.swift
@@ -26,13 +26,13 @@ public class XibFile: InterfaceBuilderFile {
 
     private static func parseContent(pathString: String) throws -> XibDocument {
         let parser = InterfaceBuilderParser()
-        let content = try String.init(contentsOfFile: pathString)
+        let content = try String(contentsOfFile: pathString)
         return try parser.parseXib(xml: content)
     }
 
     private static func parseContent(url: URL) throws -> XibDocument {
         let parser = InterfaceBuilderParser()
-        let content = try String.init(contentsOf: url)
+        let content = try String(contentsOf: url)
         return try parser.parseXib(xml: content)
     }
 }

--- a/Sources/Models/Resources/Image.swift
+++ b/Sources/Models/Resources/Image.swift
@@ -12,9 +12,9 @@ public struct Image: XMLDecodable, ResourceProtocol {
     public let width: String
     public let height: String
     public let mutableData: MutableData?
-    
+
     static func decode(_ xml: XMLIndexer) throws -> Image {
-        return Image.init(
+        return Image(
             name:          try xml.attributeValue(of: "name"),
             width:         try xml.attributeValue(of: "width"),
             height:        try xml.attributeValue(of: "height"),
@@ -27,7 +27,7 @@ public struct MutableData: XMLDecodable {
     public let content: String?
 
     static func decode(_ xml: XMLIndexer) throws -> MutableData {
-        return MutableData.init(
+        return MutableData(
             key:      try xml.attributeValue(of: "key"),
             content:  xml.element?.text)
     }

--- a/Sources/Models/Resources/NamedColor.swift
+++ b/Sources/Models/Resources/NamedColor.swift
@@ -12,7 +12,7 @@ public struct NamedColor: XMLDecodable, ResourceProtocol {
     public let color: Color?
 
     static func decode(_ xml: XMLIndexer) throws -> NamedColor {
-        return NamedColor.init(
+        return NamedColor(
             name:    try xml.attributeValue(of: "name"),
             color:   xml.byKey("color").flatMap(decodeValue))
     }

--- a/Sources/Models/UserDefinedRuntimeAttribute.swift
+++ b/Sources/Models/UserDefinedRuntimeAttribute.swift
@@ -7,11 +7,11 @@
 
 import SWXMLHash
 
-public struct UserDefinedRuntimeAttribute: XMLDecodable{
+public struct UserDefinedRuntimeAttribute: XMLDecodable {
     public let keyPath: String
     public let type: String
     public let value: Any?
-    
+
     static func decode(_ xml: XMLIndexer) throws -> UserDefinedRuntimeAttribute {
         let type: String = try xml.attributeValue(of: "type")
         let valueString: String? = xml.attributeValue(of: "value")
@@ -42,7 +42,7 @@ public struct UserDefinedRuntimeAttribute: XMLDecodable{
         default:
             value = valueString
         }
-        return UserDefinedRuntimeAttribute.init(
+        return UserDefinedRuntimeAttribute(
             keyPath:     try xml.attributeValue(of: "keyPath"),
             type:        type,
             value:       value
@@ -56,9 +56,9 @@ public struct UserDefinedRuntimeAttribute: XMLDecodable{
 public struct Range: XMLDecodable {
     public let location: Float
     public let length: Float
-    
+
     static func decode(_ xml: XMLIndexer) throws -> Range {
-        return Range.init(
+        return Range(
             location:      try xml.attributeValue(of: "location"),
             length:        try xml.attributeValue(of: "length")
         )

--- a/Sources/Models/Views/ActivityindicatorView.swift
+++ b/Sources/Models/Views/ActivityindicatorView.swift
@@ -27,7 +27,7 @@ public struct ActivityindicatorView: XMLDecodable, ViewProtocol {
     public let userDefinedRuntimeAttributes: [UserDefinedRuntimeAttribute]?
 
     static func decode(_ xml: XMLIndexer) throws -> ActivityindicatorView {
-        return ActivityindicatorView.init(
+        return ActivityindicatorView(
             id:                                        try xml.attributeValue(of: "id"),
             autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),
             clipsSubviews:                             xml.attributeValue(of: "clipsSubviews"),

--- a/Sources/Models/Views/AnyView.swift
+++ b/Sources/Models/Views/AnyView.swift
@@ -95,7 +95,7 @@ public struct Rect: XMLDecodable {
     public let key: String?
 
     static func decode(_ xml: XMLIndexer) throws -> Rect {
-        return Rect.init(
+        return Rect(
             x:      try xml.attributeValue(of: "x"),
             y:      try xml.attributeValue(of: "y"),
             width:  try xml.attributeValue(of: "width"),
@@ -111,9 +111,9 @@ public struct Point: XMLDecodable {
     public let x: Float
     public let y: Float
     public let key: String?
-    
+
     static func decode(_ xml: XMLIndexer) throws -> Point {
-        return Point.init(
+        return Point(
             x:      try xml.attributeValue(of: "x"),
             y:      try xml.attributeValue(of: "y"),
             key:    xml.attributeValue(of: "key")
@@ -128,7 +128,7 @@ public struct AutoresizingMask: XMLDecodable {
     public let heightSizable: Bool
 
     static func decode(_ xml: XMLIndexer) throws -> AutoresizingMask {
-        return try AutoresizingMask.init(
+        return try AutoresizingMask(
             widthSizable:  xml.attributeValue(of: "widthSizable"),
             heightSizable: xml.attributeValue(of: "heightSizable"))
     }
@@ -176,7 +176,7 @@ public struct Constraint: XMLDecodable {
             }
         }
 
-        public static func ==(lhs: LayoutAttribute, rhs: LayoutAttribute) -> Bool {
+        public static func == (lhs: LayoutAttribute, rhs: LayoutAttribute) -> Bool {
             switch (lhs, rhs) {
             case (.left, .left), (.right, .right), (.top, .top), (.bottom, .bottom),
                  (.leading, .leading), (.trailing, .trailing), (.width, .width),
@@ -191,7 +191,7 @@ public struct Constraint: XMLDecodable {
     }
 
     static func decode(_ xml: XMLIndexer) throws -> Constraint {
-        return Constraint.init(
+        return Constraint(
             id:              try xml.attributeValue(of: "id"),
             constant:        xml.attributeValue(of: "constant"),
             multiplier:      xml.attributeValue(of: "multiplier"),
@@ -227,7 +227,7 @@ public enum Color: XMLDecodable {
         default: return nil
         }
     }
-    
+
     static func decode(_ xml: XMLIndexer) throws -> Color {
         if let colorSpace: String = xml.attributeValue(of: "colorSpace") {
             let key: String? = xml.attributeValue(of: "key")

--- a/Sources/Models/Views/Bar/NavigationBar.swift
+++ b/Sources/Models/Views/Bar/NavigationBar.swift
@@ -10,7 +10,7 @@ import SWXMLHash
 public struct NavigationBar: XMLDecodable, ViewProtocol {
     public let id: String
     public let elementClass: String = "UINavigationBar"
-    
+
     public let autoresizingMask: AutoresizingMask?
     public let clipsSubviews: Bool?
     public let constraints: [Constraint]?
@@ -25,16 +25,15 @@ public struct NavigationBar: XMLDecodable, ViewProtocol {
     public let translatesAutoresizingMaskIntoConstraints: Bool?
     public let userInteractionEnabled: Bool?
     public let userDefinedRuntimeAttributes: [UserDefinedRuntimeAttribute]?
-    
-    
+
     public struct NavigationItem: XMLDecodable {
         public let id: String
         public let style: String?
         public let systemItem: String?
         public let title: String?
-        
+
         static func decode(_ xml: XMLIndexer) throws -> NavigationBar.NavigationItem {
-            return NavigationItem.init(
+            return NavigationItem(
                 id:         try xml.attributeValue(of: "id"),
                 style:      xml.attributeValue(of: "style"),
                 systemItem: xml.attributeValue(of: "systemItem"),
@@ -42,9 +41,9 @@ public struct NavigationBar: XMLDecodable, ViewProtocol {
             )
         }
     }
-    
+
     static func decode(_ xml: XMLIndexer) throws -> NavigationBar {
-        return NavigationBar.init(
+        return NavigationBar(
             id:                                        try xml.attributeValue(of: "id"),
             autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),
             clipsSubviews:                             xml.attributeValue(of: "clipsSubviews"),

--- a/Sources/Models/Views/Bar/SearchBar.swift
+++ b/Sources/Models/Views/Bar/SearchBar.swift
@@ -27,7 +27,7 @@ public struct SearchBar: XMLDecodable, ViewProtocol {
     public let userDefinedRuntimeAttributes: [UserDefinedRuntimeAttribute]?
 
     static func decode(_ xml: XMLIndexer) throws -> SearchBar {
-        return SearchBar.init(
+        return SearchBar(
             id:                                        try xml.attributeValue(of: "id"),
             autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),
             clipsSubviews:                             xml.attributeValue(of: "clipsSubviews"),

--- a/Sources/Models/Views/Bar/TabBar.swift
+++ b/Sources/Models/Views/Bar/TabBar.swift
@@ -10,7 +10,7 @@ import SWXMLHash
 public struct TabBar: XMLDecodable, ViewProtocol {
     public let id: String
     public let elementClass: String = "UITabBar"
-    
+
     public let autoresizingMask: AutoresizingMask?
     public let clipsSubviews: Bool?
     public let constraints: [Constraint]?
@@ -26,15 +26,14 @@ public struct TabBar: XMLDecodable, ViewProtocol {
     public let userInteractionEnabled: Bool?
     public let userDefinedRuntimeAttributes: [UserDefinedRuntimeAttribute]?
 
-
     public struct TabBarItem: XMLDecodable {
         public let id: String
         public let style: String?
         public let systemItem: String?
         public let title: String?
-        
+
         static func decode(_ xml: XMLIndexer) throws -> TabBar.TabBarItem {
-            return TabBarItem.init(
+            return TabBarItem(
                 id:         try xml.attributeValue(of: "id"),
                 style:      xml.attributeValue(of: "style"),
                 systemItem: xml.attributeValue(of: "systemItem"),
@@ -42,9 +41,9 @@ public struct TabBar: XMLDecodable, ViewProtocol {
             )
         }
     }
-    
+
     static func decode(_ xml: XMLIndexer) throws -> TabBar {
-        return TabBar.init(
+        return TabBar(
             id:                                        try xml.attributeValue(of: "id"),
             autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),
             clipsSubviews:                             xml.attributeValue(of: "clipsSubviews"),
@@ -63,4 +62,3 @@ public struct TabBar: XMLDecodable, ViewProtocol {
         )
     }
 }
-

--- a/Sources/Models/Views/Bar/Toolbar.swift
+++ b/Sources/Models/Views/Bar/Toolbar.swift
@@ -26,7 +26,6 @@ public struct Toolbar: XMLDecodable, ViewProtocol {
     public let userInteractionEnabled: Bool?
     public let userDefinedRuntimeAttributes: [UserDefinedRuntimeAttribute]?
 
-
     public struct BarButtonItem: XMLDecodable {
         public let id: String
         public let style: String?
@@ -34,7 +33,7 @@ public struct Toolbar: XMLDecodable, ViewProtocol {
         public let title: String?
 
         static func decode(_ xml: XMLIndexer) throws -> Toolbar.BarButtonItem {
-            return BarButtonItem.init(
+            return BarButtonItem(
                 id:         try xml.attributeValue(of: "id"),
                 style:      xml.attributeValue(of: "style"),
                 systemItem: xml.attributeValue(of: "systemItem"),
@@ -44,7 +43,7 @@ public struct Toolbar: XMLDecodable, ViewProtocol {
     }
 
     static func decode(_ xml: XMLIndexer) throws -> Toolbar {
-        return Toolbar.init(
+        return Toolbar(
             id:                                        try xml.attributeValue(of: "id"),
             autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),
             clipsSubviews:                             xml.attributeValue(of: "clipsSubviews"),

--- a/Sources/Models/Views/Controls/Button.swift
+++ b/Sources/Models/Views/Controls/Button.swift
@@ -42,11 +42,13 @@ public struct Button: XMLDecodable, ViewProtocol {
             let allState = try xml.byKey("state").all
 
             func title(for key: String) -> String? {
-                guard let stateElement = try? allState.first(where: { try $0.attributeValue(of: "key") == key }) else { return nil }
+                guard let stateElement = try? allState.first(where: { try $0.attributeValue(of: "key") == key }) else {
+                    return nil
+                }
                 return stateElement.flatMap { try? $0.attributeValue(of: "title") }
             }
 
-            return Title.init(
+            return Title(
                 disabled: title(for: "disabled"),
                 highlighted: title(for: "highlighted"),
                 normal: title(for: "normal"),
@@ -65,10 +67,12 @@ public struct Button: XMLDecodable, ViewProtocol {
             let allState = try xml.byKey("state").all
 
             func color(for key: String) -> Color? {
-                guard let colorElement = try? allState.first(where: { try $0.attributeValue(of: "key") == key })?.byKey("color") else { return nil }
+                guard let colorElement = try? allState.first(where: { try $0.attributeValue(of: "key") == key })?.byKey("color") else {
+                    return nil
+                }
                 return colorElement.flatMap { try? Color.decode($0) }
             }
-            return TextColor.init(
+            return TextColor(
                 normal: color(for: "normal"),
                 disabled: color(for: "disabled"),
                 selected: color(for: "selected"),
@@ -78,7 +82,7 @@ public struct Button: XMLDecodable, ViewProtocol {
     }
 
     static func decode(_ xml: XMLIndexer) throws -> Button {
-        return Button.init(
+        return Button(
             id:                                        try xml.attributeValue(of: "id"),
             autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),
             buttonType:                                xml.attributeValue(of: "buttonType"),
@@ -95,8 +99,8 @@ public struct Button: XMLDecodable, ViewProtocol {
             opaque:                                    xml.attributeValue(of: "opaque"),
             rect:                                      try decodeValue(xml.byKey("rect")),
             subviews:                                  xml.byKey("subviews")?.children.flatMap(decodeValue),
-            textColor:                                 try decodeValue(xml),
-            title:                                     try decodeValue(xml),
+            textColor:                                 try TextColor.decode(xml),
+            title:                                     try Title.decode(xml),
             translatesAutoresizingMaskIntoConstraints: xml.attributeValue(of: "translatesAutoresizingMaskIntoConstraints"),
             userInteractionEnabled:                    xml.attributeValue(of: "userInteractionEnabled"),
             userDefinedRuntimeAttributes:              xml.byKey("userDefinedRuntimeAttributes")?.byKey("userDefinedRuntimeAttribute")?.all.flatMap(decodeValue)

--- a/Sources/Models/Views/Controls/DatePicker.swift
+++ b/Sources/Models/Views/Controls/DatePicker.swift
@@ -27,7 +27,7 @@ public struct DatePicker: XMLDecodable, ViewProtocol {
     public let userDefinedRuntimeAttributes: [UserDefinedRuntimeAttribute]?
 
     static func decode(_ xml: XMLIndexer) throws -> DatePicker {
-        return DatePicker.init(
+        return DatePicker(
             id:                                        try xml.attributeValue(of: "id"),
             autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),
             clipsSubviews:                             xml.attributeValue(of: "clipsSubviews"),

--- a/Sources/Models/Views/Controls/PageControl.swift
+++ b/Sources/Models/Views/Controls/PageControl.swift
@@ -27,7 +27,7 @@ public struct PageControl: XMLDecodable, ViewProtocol {
     public let userDefinedRuntimeAttributes: [UserDefinedRuntimeAttribute]?
 
     static func decode(_ xml: XMLIndexer) throws -> PageControl {
-        return PageControl.init(
+        return PageControl(
             id:                                        try xml.attributeValue(of: "id"),
             autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),
             clipsSubviews:                             xml.attributeValue(of: "clipsSubviews"),

--- a/Sources/Models/Views/Controls/SegmentedControl.swift
+++ b/Sources/Models/Views/Controls/SegmentedControl.swift
@@ -34,12 +34,12 @@ public struct SegmentedControl: XMLDecodable, ViewProtocol {
         public let title: String
 
         static func decode(_ xml: XMLIndexer) throws -> SegmentedControl.Segment {
-            return try Segment.init(title: xml.attributeValue(of: "title"))
+            return try Segment(title: xml.attributeValue(of: "title"))
         }
     }
 
     static func decode(_ xml: XMLIndexer) throws -> SegmentedControl {
-        return SegmentedControl.init(
+        return SegmentedControl(
             id:                                         try xml.attributeValue(of: "id"),
             autoresizingMask:                           xml.byKey("autoresizingMask").flatMap(decodeValue),
             clipsSubviews:                              xml.attributeValue(of: "clipsSubviews"),

--- a/Sources/Models/Views/Controls/Slider.swift
+++ b/Sources/Models/Views/Controls/Slider.swift
@@ -27,7 +27,7 @@ public struct Slider: XMLDecodable, ViewProtocol {
     public let userDefinedRuntimeAttributes: [UserDefinedRuntimeAttribute]?
 
     static func decode(_ xml: XMLIndexer) throws -> Slider {
-        return Slider.init(
+        return Slider(
             id:                                        try xml.attributeValue(of: "id"),
             autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),
             clipsSubviews:                             xml.attributeValue(of: "clipsSubviews"),

--- a/Sources/Models/Views/Controls/Stepper.swift
+++ b/Sources/Models/Views/Controls/Stepper.swift
@@ -27,7 +27,7 @@ public struct Stepper: XMLDecodable, ViewProtocol {
     public let userDefinedRuntimeAttributes: [UserDefinedRuntimeAttribute]?
 
     static func decode(_ xml: XMLIndexer) throws -> Stepper {
-        return Stepper.init(
+        return Stepper(
             id:                                        try xml.attributeValue(of: "id"),
             autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),
             clipsSubviews:                             xml.attributeValue(of: "clipsSubviews"),

--- a/Sources/Models/Views/Controls/Switch.swift
+++ b/Sources/Models/Views/Controls/Switch.swift
@@ -32,7 +32,7 @@ public struct Switch: XMLDecodable, ViewProtocol {
     public let userDefinedRuntimeAttributes: [UserDefinedRuntimeAttribute]?
 
     static func decode(_ xml: XMLIndexer) throws -> Switch {
-        return Switch.init(
+        return Switch(
             id:                                        try xml.attributeValue(of: "id"),
             autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),
             clipsSubviews:                             xml.attributeValue(of: "clipsSubviews"),

--- a/Sources/Models/Views/Controls/TextField.swift
+++ b/Sources/Models/Views/Controls/TextField.swift
@@ -33,7 +33,7 @@ public struct TextField: XMLDecodable, ViewProtocol {
     public let userDefinedRuntimeAttributes: [UserDefinedRuntimeAttribute]?
 
     static func decode(_ xml: XMLIndexer) throws -> TextField {
-        return TextField.init(
+        return TextField(
             id:                                        try xml.attributeValue(of: "id"),
             autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),
             borderStyle:                               xml.attributeValue(of: "borderStyle"),

--- a/Sources/Models/Views/Controls/TextView.swift
+++ b/Sources/Models/Views/Controls/TextView.swift
@@ -35,7 +35,7 @@ public struct TextView: XMLDecodable, ViewProtocol {
     public let userDefinedRuntimeAttributes: [UserDefinedRuntimeAttribute]?
 
     static func decode(_ xml: XMLIndexer) throws -> TextView {
-        return TextView.init(
+        return TextView(
             id:                                        try xml.attributeValue(of: "id"),
             autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),
             bounces:                                   xml.attributeValue(of: "bounces"),

--- a/Sources/Models/Views/Frameworks/ARSCNView.swift
+++ b/Sources/Models/Views/Frameworks/ARSCNView.swift
@@ -27,7 +27,7 @@ public struct ARSCNView: XMLDecodable, ViewProtocol {
     public let userDefinedRuntimeAttributes: [UserDefinedRuntimeAttribute]?
 
     static func decode(_ xml: XMLIndexer) throws -> ARSCNView {
-        return ARSCNView.init(
+        return ARSCNView(
             id:                                        try xml.attributeValue(of: "id"),
             autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),
             clipsSubviews:                             xml.attributeValue(of: "clipsSubviews"),

--- a/Sources/Models/Views/Frameworks/ARSKView.swift
+++ b/Sources/Models/Views/Frameworks/ARSKView.swift
@@ -27,7 +27,7 @@ public struct ARSKView: XMLDecodable, ViewProtocol {
     public let userDefinedRuntimeAttributes: [UserDefinedRuntimeAttribute]?
 
     static func decode(_ xml: XMLIndexer) throws -> ARSKView {
-        return ARSKView.init(
+        return ARSKView(
             id:                                        try xml.attributeValue(of: "id"),
             autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),
             clipsSubviews:                             xml.attributeValue(of: "clipsSubviews"),

--- a/Sources/Models/Views/Frameworks/GLKView.swift
+++ b/Sources/Models/Views/Frameworks/GLKView.swift
@@ -27,7 +27,7 @@ public struct GLKView: XMLDecodable, ViewProtocol {
     public let userDefinedRuntimeAttributes: [UserDefinedRuntimeAttribute]?
 
     static func decode(_ xml: XMLIndexer) throws -> GLKView {
-        return GLKView.init(
+        return GLKView(
             id:                                        try xml.attributeValue(of: "id"),
             autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),
             clipsSubviews:                             xml.attributeValue(of: "clipsSubviews"),

--- a/Sources/Models/Views/Frameworks/MTKView.swift
+++ b/Sources/Models/Views/Frameworks/MTKView.swift
@@ -27,7 +27,7 @@ public struct MTKView: XMLDecodable, ViewProtocol {
     public let userDefinedRuntimeAttributes: [UserDefinedRuntimeAttribute]?
 
     static func decode(_ xml: XMLIndexer) throws -> MTKView {
-        return MTKView.init(
+        return MTKView(
             id:                                        try xml.attributeValue(of: "id"),
             autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),
             clipsSubviews:                             xml.attributeValue(of: "clipsSubviews"),

--- a/Sources/Models/Views/Frameworks/MapView.swift
+++ b/Sources/Models/Views/Frameworks/MapView.swift
@@ -27,7 +27,7 @@ public struct MapView: XMLDecodable, ViewProtocol {
     public let userDefinedRuntimeAttributes: [UserDefinedRuntimeAttribute]?
 
     static func decode(_ xml: XMLIndexer) throws -> MapView {
-        return MapView.init(
+        return MapView(
             id:                                        try xml.attributeValue(of: "id"),
             autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),
             clipsSubviews:                             xml.attributeValue(of: "clipsSubviews"),

--- a/Sources/Models/Views/Frameworks/SKView.swift
+++ b/Sources/Models/Views/Frameworks/SKView.swift
@@ -27,7 +27,7 @@ public struct SKView: XMLDecodable, ViewProtocol {
     public let userDefinedRuntimeAttributes: [UserDefinedRuntimeAttribute]?
 
     static func decode(_ xml: XMLIndexer) throws -> SKView {
-        return SKView.init(
+        return SKView(
             id:                                        try xml.attributeValue(of: "id"),
             autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),
             clipsSubviews:                             xml.attributeValue(of: "clipsSubviews"),

--- a/Sources/Models/Views/Frameworks/SceneKitView.swift
+++ b/Sources/Models/Views/Frameworks/SceneKitView.swift
@@ -27,7 +27,7 @@ public struct SceneKitView: XMLDecodable, ViewProtocol {
     public let userDefinedRuntimeAttributes: [UserDefinedRuntimeAttribute]?
 
     static func decode(_ xml: XMLIndexer) throws -> SceneKitView {
-        return SceneKitView.init(
+        return SceneKitView(
             id:                                        try xml.attributeValue(of: "id"),
             autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),
             clipsSubviews:                             xml.attributeValue(of: "clipsSubviews"),

--- a/Sources/Models/Views/Frameworks/WKWebView.swift
+++ b/Sources/Models/Views/Frameworks/WKWebView.swift
@@ -27,7 +27,7 @@ public struct WKWebView: XMLDecodable, ViewProtocol {
     public let userDefinedRuntimeAttributes: [UserDefinedRuntimeAttribute]?
 
     static func decode(_ xml: XMLIndexer) throws -> WKWebView {
-        return WKWebView.init(
+        return WKWebView(
             id:                                        try xml.attributeValue(of: "id"),
             autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),
             clipsSubviews:                             xml.attributeValue(of: "clipsSubviews"),

--- a/Sources/Models/Views/ImageView.swift
+++ b/Sources/Models/Views/ImageView.swift
@@ -29,7 +29,7 @@ public struct ImageView: XMLDecodable, ViewProtocol {
     public let userDefinedRuntimeAttributes: [UserDefinedRuntimeAttribute]?
 
     static func decode(_ xml: XMLIndexer) throws -> ImageView {
-        return ImageView.init(
+        return ImageView(
             id:                                        try xml.attributeValue(of: "id"),
             autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),
             clipsSubviews:                             xml.attributeValue(of: "clipsSubviews"),

--- a/Sources/Models/Views/Label.swift
+++ b/Sources/Models/Views/Label.swift
@@ -34,9 +34,8 @@ public struct Label: XMLDecodable, ViewProtocol {
     public let verticalHuggingPriority: Int?
     public let userDefinedRuntimeAttributes: [UserDefinedRuntimeAttribute]?
 
-
     static func decode(_ xml: XMLIndexer) throws -> Label {
-        return Label.init(
+        return Label(
             id:                                        try xml.attributeValue(of: "id"),
             adjustsFontSizeToFit:                      xml.attributeValue(of: "adjustsFontSizeToFit"),
             autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),
@@ -73,7 +72,7 @@ public struct FontDescription: XMLDecodable {
     public let weight: String?
 
     static func decode(_ xml: XMLIndexer) throws -> FontDescription {
-        return FontDescription.init(
+        return FontDescription(
             type:      try xml.attributeValue(of: "type"),
             pointSize: try xml.attributeValue(of: "pointSize"),
             weight:    xml.attributeValue(of: "weight")

--- a/Sources/Models/Views/Picker.swift
+++ b/Sources/Models/Views/Picker.swift
@@ -26,7 +26,7 @@ public struct PickerView: XMLDecodable, ViewProtocol {
     public let userDefinedRuntimeAttributes: [UserDefinedRuntimeAttribute]?
 
     static func decode(_ xml: XMLIndexer) throws -> PickerView {
-        return PickerView.init(
+        return PickerView(
             id:                                        try xml.attributeValue(of: "id"),
             autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),
             clipsSubviews:                             xml.attributeValue(of: "clipsSubviews"),

--- a/Sources/Models/Views/ProgressView.swift
+++ b/Sources/Models/Views/ProgressView.swift
@@ -27,7 +27,7 @@ public struct ProgressView: XMLDecodable, ViewProtocol {
     public let userDefinedRuntimeAttributes: [UserDefinedRuntimeAttribute]?
 
     static func decode(_ xml: XMLIndexer) throws -> ProgressView {
-        return ProgressView.init(
+        return ProgressView(
             id:                                        try xml.attributeValue(of: "id"),
             autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),
             clipsSubviews:                             xml.attributeValue(of: "clipsSubviews"),

--- a/Sources/Models/Views/ScrollViews/CollectionView.swift
+++ b/Sources/Models/Views/ScrollViews/CollectionView.swift
@@ -29,7 +29,7 @@ public struct CollectionView: XMLDecodable, ViewProtocol {
     public let userDefinedRuntimeAttributes: [UserDefinedRuntimeAttribute]?
 
     static func decode(_ xml: XMLIndexer) throws -> CollectionView {
-        return CollectionView.init(
+        return CollectionView(
             id:                                        try xml.attributeValue(of: "id"),
             alwaysBounceHorizontal:                    xml.attributeValue(of: "alwaysBounceHorizontal"),
             autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),
@@ -74,7 +74,7 @@ public struct CollectionViewCell: XMLDecodable, ViewProtocol {
     public let userDefinedRuntimeAttributes: [UserDefinedRuntimeAttribute]?
 
     static func decode(_ xml: XMLIndexer) throws -> CollectionViewCell {
-        return CollectionViewCell.init(
+        return CollectionViewCell(
             id:                                        try xml.attributeValue(of: "id"),
             autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),
             clipsSubviews:                             xml.attributeValue(of: "clipsSubviews"),

--- a/Sources/Models/Views/ScrollViews/ScrollView.swift
+++ b/Sources/Models/Views/ScrollViews/ScrollView.swift
@@ -26,7 +26,7 @@ public struct ScrollView: XMLDecodable, ViewProtocol {
     public let userDefinedRuntimeAttributes: [UserDefinedRuntimeAttribute]?
 
     static func decode(_ xml: XMLIndexer) throws -> ScrollView {
-        return ScrollView.init(
+        return ScrollView(
             id:                                        try xml.attributeValue(of: "id"),
             autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),
             clipsSubviews:                             xml.attributeValue(of: "clipsSubviews"),

--- a/Sources/Models/Views/ScrollViews/TableView.swift
+++ b/Sources/Models/Views/ScrollViews/TableView.swift
@@ -50,7 +50,7 @@ public struct TableView: XMLDecodable, ViewProtocol {
     }
 
     static func decode(_ xml: XMLIndexer) throws -> TableView {
-        return TableView.init(
+        return TableView(
             id:                                        try xml.attributeValue(of: "id"),
             alwaysBounceVertical:                      xml.attributeValue(of: "alwaysBounceVertical"),
             autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),
@@ -121,7 +121,7 @@ public struct TableViewCell: XMLDecodable, ViewProtocol {
         public let userDefinedRuntimeAttributes: [UserDefinedRuntimeAttribute]?
 
         static func decode(_ xml: XMLIndexer) throws -> TableViewCell.TableViewContentView {
-            return TableViewContentView.init(
+            return TableViewContentView(
                 id:                                        try xml.attributeValue(of: "id"),
                 autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),
                 clipsSubviews:                             xml.attributeValue(of: "clipsSubviews"),
@@ -141,7 +141,7 @@ public struct TableViewCell: XMLDecodable, ViewProtocol {
     }
 
     static func decode(_ xml: XMLIndexer) throws -> TableViewCell {
-        return TableViewCell.init(
+        return TableViewCell(
             id:                                        try xml.attributeValue(of: "id"),
             autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),
             clipsSubviews:                             xml.attributeValue(of: "clipsSubviews"),

--- a/Sources/Models/Views/StackView.swift
+++ b/Sources/Models/Views/StackView.swift
@@ -28,7 +28,7 @@ public struct StackView: XMLDecodable, ViewProtocol {
     public let userDefinedRuntimeAttributes: [UserDefinedRuntimeAttribute]?
 
     static func decode(_ xml: XMLIndexer) throws -> StackView {
-        return StackView.init(
+        return StackView(
             id:                                        try xml.attributeValue(of: "id"),
             alignment:                                 xml.attributeValue(of: "alignment"),
             autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),

--- a/Sources/Models/Views/View.swift
+++ b/Sources/Models/Views/View.swift
@@ -28,7 +28,7 @@ public struct View: XMLDecodable, ViewProtocol {
     public let userDefinedRuntimeAttributes: [UserDefinedRuntimeAttribute]?
 
     static func decode(_ xml: XMLIndexer) throws -> View {
-        return View.init(
+        return View(
             id:                                        try xml.attributeValue(of: "id"),
             autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),
             clipsSubviews:                             xml.attributeValue(of: "clipsSubviews"),
@@ -55,7 +55,7 @@ public struct LayoutGuide: XMLDecodable {
     public let id: String
 
     static func decode(_ xml: XMLIndexer) throws -> LayoutGuide {
-        return try LayoutGuide.init(
+        return try LayoutGuide(
             key: xml.attributeValue(of: "key"),
             id: xml.attributeValue(of: "id")
         )

--- a/Sources/Models/Views/VisualEffectView.swift
+++ b/Sources/Models/Views/VisualEffectView.swift
@@ -27,7 +27,7 @@ public struct VisualEffectView: XMLDecodable, ViewProtocol {
     public let userDefinedRuntimeAttributes: [UserDefinedRuntimeAttribute]?
 
     static func decode(_ xml: XMLIndexer) throws -> VisualEffectView {
-        return VisualEffectView.init(
+        return VisualEffectView(
             id:                                        try xml.attributeValue(of: "id"),
             autoresizingMask:                          xml.byKey("autoresizingMask").flatMap(decodeValue),
             clipsSubviews:                             xml.attributeValue(of: "clipsSubviews"),

--- a/Sources/Parsers/InterfaceBuilderParser.swift
+++ b/Sources/Parsers/InterfaceBuilderParser.swift
@@ -15,7 +15,7 @@ public struct InterfaceBuilderParser {
     private let xmlParser: SWXMLHash
 
     public init() {
-        xmlParser = SWXMLHash.config({_ in})
+        xmlParser = SWXMLHash.config({ _ in })
     }
 
     public func parseStoryboard(xml: String) throws -> StoryboardDocument {

--- a/Sources/Parsers/XMLDecodable.swift
+++ b/Sources/Parsers/XMLDecodable.swift
@@ -4,5 +4,3 @@
 //
 //  Created by SaitoYuta on 2017/12/10.
 //
-
-


### PR DESCRIPTION
remove useless space, or add missing one
remove `.init(`, it's an objective c style

I did not remove all spaces in code like that
```swift
id:                            try xml.attributeValue(of: \"id\"),\n")
autoresizingMask:              xml.by
```
The swiftlint warning is [colon](https://github.com/realm/SwiftLint/blob/2840d58e24f7b5dc5b376aa7a2feaa7fa51662d6/Rules.md#colon)

I do not commit SWXMLHash+Extension.swift with 1 warning (have too much modification in it because of my instrumentation (I know I can stash but...)