### PR TITLE
Disable remote resource test on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ install: swift package update
 script:
   - swift build
   - swift build -c release
-  - swift test
+  - swift test -Xswiftc "-DDISABLE_REMOTE_RESOURCES_TEST"
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/Tests/MissingAttributeTests.swift
+++ b/Tests/MissingAttributeTests.swift
@@ -8,6 +8,8 @@
 import XCTest
 @testable import IBDecodable
 
+#if DISABLE_REMOTE_RESOURCES_TEST
+#else
 class MissingAttributeTests: XCTestCase {
 
     lazy var cacheDirPath: URL = {
@@ -251,3 +253,4 @@ class TraverseXMLIndexerContainer<K: CodingKey>: XMLIndexerContainer<K> {
         return elements.map(TraverseXMLIndexerContainer<A>.init)
     }
 }
+#endif


### PR DESCRIPTION
I didn't know environment variable is not available to job triggered by PR. 😿
Sorry for some CI failing.