### PR TITLE
Bugfix/labels

### DIFF
--- a/Sources/IBError.swift
+++ b/Sources/IBError.swift
@@ -14,6 +14,7 @@ public enum IBError: Swift.Error, CustomStringConvertible {
     case unsupportedConstraint(String)
     case unsupportedTableViewDataMode(String)
     case unsupportedColorSpace(String)
+    case unsupportedFontDescription
 
     public var description: String {
         switch self {
@@ -29,6 +30,8 @@ public enum IBError: Swift.Error, CustomStringConvertible {
             return "unsupported dataMode '\(name)'"
         case .unsupportedColorSpace(let colorSpace):
             return "unsupported color space '\(colorSpace)'"
+        case .unsupportedFontDescription:
+            return "unsupported font description"
         }
     }
 }

--- a/Tests/Resources/LabelsWithFonts.xib
+++ b/Tests/Resources/LabelsWithFonts.xib
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="UIViewController">
+            <connections>
+                <outlet property="view" destination="iN0-l3-epB" id="82N-rv-Sgm"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="C4w-0I-Z9x">
+                    <rect key="frame" x="165.5" y="303.5" width="44.5" height="60.5"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3fY-er-wyA">
+                            <rect key="frame" x="0.0" y="0.0" width="44.5" height="20.5"/>
+                            <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mfd-MB-XgM">
+                            <rect key="frame" x="0.0" y="20.5" width="43" height="20.5"/>
+                            <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Mna-bb-6HE">
+                            <rect key="frame" x="0.0" y="41" width="39.5" height="19.5"/>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                </stackView>
+            </subviews>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstItem="C4w-0I-Z9x" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="Kkv-bc-RVg"/>
+                <constraint firstItem="C4w-0I-Z9x" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="NvC-VB-nJc"/>
+            </constraints>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+        </view>
+    </objects>
+</document>

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -301,6 +301,46 @@ class Tests: XCTestCase {
         }
     }
 
+    func testLabelsWithFonts() {
+        let url = self.url(forResource: "LabelsWithFonts", withExtension: "xib")
+        do {
+            let file = try XibFile(url: url)
+
+            let rootView = file.document.views?.first?.view
+            XCTAssertNotNil(rootView, "There should be a root view")
+
+            let stackView = rootView?.subviews?.first?.view
+            XCTAssertNotNil(stackView, "There should be a stack view")
+            XCTAssertEqual(stackView?.elementClass, "UIStackView")
+
+            let labels = (stackView?.subviews ?? []).compactMap { $0.view as? Label }
+            XCTAssertEqual(labels.count, 3)
+
+            let fontDescriptions = labels.compactMap { $0.fontDescription }
+            XCTAssertEqual(fontDescriptions.count, 3)
+
+            let customFont = fontDescriptions[0]
+            guard case .custom = customFont else {
+                XCTFail("The label should have a custom type")
+                return
+            }
+
+            let systemFont = fontDescriptions[1]
+            guard case .system = systemFont else {
+                XCTFail("The label should have a system type")
+                return
+            }
+
+            let textStyle = fontDescriptions[2]
+            guard case .textStyle = textStyle else {
+                XCTFail("The label should have a textStyle type")
+                return
+            }
+        } catch {
+            XCTFail("\(error)  \(url)")
+        }
+    }
+
     // MARK: Utils
 
     lazy var bundle: Bundle = {


### PR DESCRIPTION
Some properties were missing in the `FontDescription` struct. Instead of having a struct with most of the properties nil, this is now an enum.
