### PR TITLE
Add new attribute `destinationCreationSelector` on `Segue` for `@IBSegueAction`

### DIFF
--- a/Sources/Models/Connections/Segue.swift
+++ b/Sources/Models/Connections/Segue.swift
@@ -13,6 +13,7 @@ public struct Segue: IBDecodable, ConnectionProtocol {
     public let kind: Segue.Kind
     public let relationship: String?
     public let identifier: String?
+    public let destinationCreationSelector: String?
 
     static func decode(_ xml: XMLIndexerType) throws -> Segue {
         let container = xml.container(keys: CodingKeys.self)
@@ -21,7 +22,8 @@ public struct Segue: IBDecodable, ConnectionProtocol {
             destination:   try container.attribute(of: .destination),
             kind:          try container.attribute(of: .kind),
             relationship:  container.attributeIfPresent(of: .relationship),
-            identifier:    container.attributeIfPresent(of: .identifier)
+            identifier:    container.attributeIfPresent(of: .identifier),
+            destinationCreationSelector:  container.attributeIfPresent(of: .destinationCreationSelector)
         )
     }
 

--- a/Tests/Resources/StoryboardConnections.storyboard
+++ b/Tests/Resources/StoryboardConnections.storyboard
@@ -113,6 +113,7 @@
                     <navigationItem key="navigationItem" title="Root View Controller" id="xiz-i2-ses"/>
                     <connections>
                         <segue destination="ElF-Se-9Ra" kind="showDetail" identifier="test" id="E9O-7R-REh"/>
+                        <segue destination="ElF-Se-9Ra" kind="show" destinationCreationSelector="aSegueAction:" id="71I-4Y-Tjy"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ae6-X0-vsc" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -141,7 +141,7 @@ class Tests: XCTestCase {
             XCTAssertFalse(rootConnections.isEmpty)
 
             let connections: [AnyConnection] = file.document.children(of: AnyConnection.self)
-            XCTAssertEqual(connections.count, 9)
+            XCTAssertEqual(connections.count, 10)
         } catch {
             XCTFail("\(error)")
         }


### PR DESCRIPTION
New feature of Xcode 11
A custom selector to create the controller when activating the segue

https://useyourloaf.com/blog/better-storyboards-with-xcode-11/