### PR TITLE
Add on `Image` the attribute `catalog` for SF Symbols images

### DIFF
--- a/Sources/Models/Resources/Image.swift
+++ b/Sources/Models/Resources/Image.swift
@@ -11,6 +11,7 @@ public struct Image: IBDecodable, ResourceProtocol {
     public let name: String
     public let width: String
     public let height: String
+    public let catalog: String?
     public let mutableData: MutableData?
 
     static func decode(_ xml: XMLIndexerType) throws -> Image {
@@ -19,6 +20,7 @@ public struct Image: IBDecodable, ResourceProtocol {
             name:          try container.attribute(of: .name),
             width:         try container.attribute(of: .width),
             height:        try container.attribute(of: .height),
+            catalog:       container.attributeIfPresent(of: .catalog),
             mutableData:   container.elementIfPresent(of: .mutableData))
     }
 }

--- a/Tests/Resources/StoryboardAsset.storyboard
+++ b/Tests/Resources/StoryboardAsset.storyboard
@@ -1,11 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15509"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -30,6 +27,10 @@
                                 <rect key="frame" x="96" y="338" width="115" height="81"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             </imageView>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="square.and.arrow.up" catalog="system" highlightedImage="square.and.arrow.up.fill" translatesAutoresizingMaskIntoConstraints="NO" id="2pH-uA-dW8">
+                                <rect key="frame" x="67" y="47" width="70" height="63"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            </imageView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <viewLayoutGuide key="safeArea" id="hhG-XG-10b"/>
@@ -42,6 +43,8 @@
     </scenes>
     <resources>
         <image name="Image" width="16" height="16"/>
+        <image name="square.and.arrow.up" catalog="system" width="56" height="64"/>
+        <image name="square.and.arrow.up.fill" catalog="system" width="56" height="64"/>
         <namedColor name="Color">
             <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>


### PR DESCRIPTION
I put a string, do not know if there is other values and we must create an enum

we have catalog="system" on image
This could help to fix https://github.com/IBDecodable/IBLinter/issues/129