### PR TITLE
Try to decode `CollectionViewCell` content view Fix #72

### DIFF
--- a/Sources/Models/Views/AnyView.swift
+++ b/Sources/Models/Views/AnyView.swift
@@ -89,6 +89,7 @@ public struct AnyView: IBDecodable {
         case "view":                     return try AnyView(View.decode(xml))
         case "visualEffectView":         return try AnyView(VisualEffectView.decode(xml))
         case "wkWebView":                return try AnyView(WKWebView.decode(xml))
+        case "collectionViewCellContentView": return try AnyView(CollectionViewCell.ContentView.decode(xml))
         default:
             throw IBError.unsupportedViewClass(elementName)
         }

--- a/Tests/Resources/CollectionViewCell2.xib
+++ b/Tests/Resources/CollectionViewCell2.xib
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="UIViewController"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="v5y-fv-StP">
+            <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO">
+                <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </collectionViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="Jkp-Kr-0cj"/>
+        </collectionViewCell>
+    </objects>
+</document>

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -325,6 +325,24 @@ class Tests: XCTestCase {
         }
     }
 
+    func testCollectionViewCellContentView2() {
+        let url = self.url(forResource: "CollectionViewCell2", withExtension: "xib")
+        do {
+            let file = try XibFile(url: url)
+            let rootView = file.document.views?.first?.view
+            XCTAssertNotNil(rootView, "There should be a root view")
+            XCTAssertEqual(rootView?.elementClass, "UICollectionViewCell")
+
+            guard let cell = rootView as? CollectionViewCell else {
+                XCTFail("The root view should be a collection view cell")
+                return
+            }
+            XCTAssertEqual(cell.contentView.key, "contentView")
+        } catch {
+            XCTFail("\(error)  \(url)")
+        }
+    }
+
     func testLabelsWithFonts() {
         let url = self.url(forResource: "LabelsWithFonts", withExtension: "xib")
         do {


### PR DESCRIPTION
using `view` or `collectionViewCellContentView` keys

Add unit test with `collectionViewCellContentView`

Rename the class because `CollectionViewContentView` is not correct. `CollectionViewCellContentView` is.
But I use a `CollectionViewCell.ContentView`