### PR TITLE
Add common protocol `IBConnectionOwner` for view and controller to provide connections

### DIFF
--- a/Sources/Models/Controllers/AnyViewController.swift
+++ b/Sources/Models/Controllers/AnyViewController.swift
@@ -9,7 +9,7 @@ import SWXMLHash
 
 // MARK: - ViewControllerProtocol
 
-public protocol ViewControllerProtocol: IBIdentifiable, IBCustomClassable, IBUserLabelable {
+public protocol ViewControllerProtocol: IBIdentifiable, IBCustomClassable, IBUserLabelable, IBConnectionOwner {
     var elementClass: String { get }
 
     var storyboardIdentifier: String? { get }

--- a/Sources/Models/Views/AnyView.swift
+++ b/Sources/Models/Views/AnyView.swift
@@ -9,7 +9,7 @@ import SWXMLHash
 
 // MARK: - ViewProtocol
 
-public protocol ViewProtocol: IBKeyable, IBCustomClassable, IBUserLabelable {
+public protocol ViewProtocol: IBKeyable, IBCustomClassable, IBUserLabelable, IBConnectionOwner {
     var elementClass: String { get }
 
     var key: String? { get }

--- a/Tests/IBDecodableTests/Tests.swift
+++ b/Tests/IBDecodableTests/Tests.swift
@@ -178,8 +178,43 @@ class Tests: XCTestCase {
             let rootConnections = viewControllers.compactMap { $0?.connections }.flatMap { $0 }.compactMap { $0.connection }
             XCTAssertFalse(rootConnections.isEmpty)
 
-            let connections: [AnyConnection] = file.document.children(of: AnyConnection.self)
-            XCTAssertEqual(connections.count, 10)
+            let connections: [AnyConnection] = file.document.children(of: AnyConnection.self, recursive: false)
+            XCTAssertEqual(connections.count, 0) // nothing at root
+
+            let connectionsVc: [AnyConnection] = file.document.scenes?.first?.viewController?.viewController.children(of: AnyConnection.self, recursive: false) ?? []
+            XCTAssertEqual(connectionsVc.count, 2)
+            XCTAssertEqual(Set(connectionsVc.map { $0.connection.id}).count, 2)
+
+            let fullIDs = ["bfr-3x-8Cu", "NCO-CC-AeV", "70a-Qv-I1V", "0Zt-4d-vGk", "T6v-mS-lhn", "71I-4Y-Tjy", "E9O-7R-REh", "o8d-bM-qoT", "4xW-di-6F5", "bnm-eN-VfU"]
+            let connectionsFull: [AnyConnection] = file.document.children(of: AnyConnection.self, recursive: true)
+            XCTAssertEqual(connectionsFull.count, fullIDs.count)
+            XCTAssertEqual(Set(connectionsFull.map { $0.connection.id}).count, fullIDs.count)
+
+            // using IBConnectionOwner
+            let connectionsAllFull: [AnyConnection] = viewControllers.compactMap { viewController in
+                viewController?.allConnections
+            }.flatMap { $0 }
+            XCTAssertEqual(connectionsAllFull.count, fullIDs.count)
+            XCTAssertEqual(Set(connectionsAllFull.map { $0.connection.id}).count, fullIDs.count)
+
+            let connectionsAllForId: [AnyConnection] = viewControllers.compactMap { viewController in
+                viewController?.connectionsWith(destination: "McG-6E-zrF")
+            }.flatMap { $0 }
+            XCTAssertEqual(connectionsAllForId.count, 3)
+            XCTAssertEqual(Set(connectionsAllForId.map { $0.connection.id}).count, 3)
+
+            let connectionsChild: [AnyConnection] = viewControllers.compactMap { viewController in
+                viewController?.childrenConnections
+            }.flatMap { $0 }
+            XCTAssertEqual(connectionsChild.count, fullIDs.count - 3)
+            XCTAssertEqual(Set(connectionsChild.map { $0.connection.id}).count, fullIDs.count - 3)
+
+            let connectionsChildForId: [AnyConnection] = viewControllers.compactMap { viewController in
+                viewController?.childrenConnectionsWith(destination: "McG-6E-zrF")
+            }.flatMap { $0 }
+            XCTAssertEqual(connectionsChildForId.count, 2)
+            XCTAssertEqual(Set(connectionsChildForId.map { $0.connection.id}).count, 2)
+
         } catch {
             XCTFail("\(error)")
         }


### PR DESCRIPTION
## what?

a protocol to play with connections

tests to check if we found the correct number of connections

## why?

when playing with one element we want to found a related connection
a connection could be `connections` var but also in parent view or controller hierarchy (we could match them with "destination" id)

For instance Xcode use the connection (outlet) to name an element in view tree (if there is no userLabel)

![Screenshot 2020-09-17 at 10 36 44](https://user-images.githubusercontent.com/8875768/93446629-b82c8480-f8d1-11ea-9bba-da740ed18a24.png)
