### PR TITLE
WIP: iOS 14 features #84

### DIFF
--- a/Sources/Models/ImageReference.swift
+++ b/Sources/Models/ImageReference.swift
@@ -1,0 +1,28 @@
+//
+//  ImageReference.swift
+//  
+//
+//  Created by phimage on 17/09/2020.
+//
+
+import Foundation
+import SWXMLHash
+
+public struct ImageReference: IBDecodable, IBKeyable {
+
+    public let key: String?
+    public let image: String
+    public let catalog: String?
+    public let symbolScale: String?
+    public let renderingMode: String?
+
+    static func decode(_ xml: XMLIndexerType) throws -> ImageReference {
+        let container = xml.container(keys: CodingKeys.self)
+        return ImageReference(
+            key:           container.attributeIfPresent(of: .key),
+            image:         try container.attribute(of: .image),
+            catalog:       container.attributeIfPresent(of: .catalog),
+            symbolScale:   container.attributeIfPresent(of: .symbolScale),
+            renderingMode: container.attributeIfPresent(of: .renderingMode))
+    }
+}

--- a/Sources/Models/Resources/AnyResource.swift
+++ b/Sources/Models/Resources/AnyResource.swift
@@ -30,6 +30,7 @@ public struct AnyResource: IBDecodable {
             throw IBError.elementNotFound
         }
         switch elementName {
+        case "systemColor":     return try AnyResource(SystemColor.decode(xml))
         case "namedColor":      return try AnyResource(NamedColor.decode(xml))
         case "image":           return try AnyResource(Image.decode(xml))
         default:

--- a/Sources/Models/Resources/SystemColor.swift
+++ b/Sources/Models/Resources/SystemColor.swift
@@ -1,0 +1,23 @@
+//
+//  SystemColor.swift
+//  IBDecodable
+//  
+//
+//  Created by phimage on 17/09/2020.
+//
+
+import Foundation
+import SWXMLHash
+
+public struct SystemColor: IBDecodable, ResourceProtocol {
+    public let name: String
+    public let color: Color?
+
+    static func decode(_ xml: XMLIndexerType) throws -> SystemColor {
+        let container = xml.container(keys: CodingKeys.self)
+        return SystemColor(
+            name:    try container.attribute(of: .name),
+            color:   container.elementIfPresent(of: .color))
+    }
+
+}

--- a/Sources/Models/Views/Controls/Switch.swift
+++ b/Sources/Models/Views/Controls/Switch.swift
@@ -41,6 +41,8 @@ public struct Switch: IBDecodable, ViewProtocol, IBIdentifiable {
     public let variations: [Variation]?
     public let backgroundColor: Color?
     public let tintColor: Color?
+    public let title: String?
+    public let preferredStyle: String?
 
     enum ConstraintsCodingKeys: CodingKey { case constraint }
     enum VariationCodingKey: CodingKey { case variation }
@@ -95,7 +97,9 @@ public struct Switch: IBDecodable, ViewProtocol, IBIdentifiable {
             connections:                               container.childrenIfPresent(of: .connections),
             variations:                                variationContainer.elementsIfPresent(of: .variation),
             backgroundColor:                           colorsContainer?.withAttributeElement(.key, CodingKeys.backgroundColor.stringValue),
-            tintColor:                                 colorsContainer?.withAttributeElement(.key, CodingKeys.tintColor.stringValue)
+            tintColor:                                 colorsContainer?.withAttributeElement(.key, CodingKeys.tintColor.stringValue),
+            title:                                     container.attributeIfPresent(of: .title),
+            preferredStyle:                            container.attributeIfPresent(of: .preferredStyle)
         )
     }
 }

--- a/Tests/Resources/StoryboardAllViews.storyboard
+++ b/Tests/Resources/StoryboardAllViews.storyboard
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="ipad12_9" orientation="portrait" layout="fullscreen" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -15,7 +17,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="1024" height="1366"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Etj-Jn-oEA">
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Etj-Jn-oEA">
                                 <rect key="frame" x="16" y="20" width="46" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
@@ -34,17 +36,19 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
-                            <slider opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="1" minValue="1" maxValue="2" continuous="NO" minimumValueImage="MinImage" maximumValueImage="MAxImage" translatesAutoresizingMaskIntoConstraints="NO" id="K1B-Mc-DDl">
+                            <slider opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="1" minValue="1" maxValue="2" continuous="NO" translatesAutoresizingMaskIntoConstraints="NO" id="K1B-Mc-DDl">
                                 <rect key="frame" x="16" y="158" width="118" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <imageReference key="minimumValueImage" image="square.and.arrow.up.on.square" catalog="system" renderingMode="original"/>
+                                <imageReference key="maximumValueImage" image="MAxImage" symbolScale="medium" renderingMode="original"/>
                                 <color key="minimumTrackTintColor" red="0.98144435880000003" green="0.57155585289999999" blue="0.041917555029999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <color key="maximumTrackTintColor" red="1" green="0.091228451069999994" blue="0.078599756620000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <color key="thumbTintColor" red="0.72846722600000002" green="0.4665229917" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </slider>
-                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="DE9-Wz-Fhx">
+                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" title="ssssss" preferredStyle="sliding" translatesAutoresizingMaskIntoConstraints="NO" id="DE9-Wz-Fhx">
                                 <rect key="frame" x="18" y="205" width="49" height="31"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="thumbTintColor" systemColor="systemRedColor" red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="thumbTintColor" systemColor="systemRedColor"/>
                             </switch>
                             <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="3UC-t4-gNH">
                                 <rect key="frame" x="18" y="261" width="20" height="20"/>
@@ -53,8 +57,8 @@
                             <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" fixedFrame="YES" progress="0.5" progressImage="MAxImage" trackImage="MinImage" translatesAutoresizingMaskIntoConstraints="NO" id="qS2-Pq-g7P">
                                 <rect key="frame" x="18" y="303" width="150" height="2"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="progressTintColor" systemColor="systemOrangeColor" red="1" green="0.58431372550000005" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <color key="trackTintColor" systemColor="systemTealColor" red="0.35294117650000001" green="0.7843137255" blue="0.98039215690000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="progressTintColor" systemColor="systemOrangeColor"/>
+                                <color key="trackTintColor" systemColor="systemTealColor"/>
                             </progressView>
                             <pageControl opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="3" translatesAutoresizingMaskIntoConstraints="NO" id="Meo-32-F7i">
                                 <rect key="frame" x="16" y="325" width="39" height="37"/>
@@ -67,6 +71,7 @@
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PRZ-LJ-cIu">
                                 <rect key="frame" x="19" y="443" width="68" height="52"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <imageReference key="image" image="square.and.arrow.up" catalog="system" symbolScale="medium" renderingMode="original"/>
                             </imageView>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="xUg-L3-Uo7">
                                 <rect key="frame" x="19" y="519" width="131" height="60"/>
@@ -231,11 +236,11 @@
                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="Mtw-4Y-o62">
                                 <rect key="frame" x="88" y="205" width="49" height="31"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="onTintColor" systemColor="systemOrangeColor" red="1" green="0.58431372550000005" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="onTintColor" systemColor="systemOrangeColor"/>
                             </switch>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <viewLayoutGuide key="safeArea" id="tPV-Am-8N4"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     </view>
                     <connections>
                         <outlet property="searchDisplayController" destination="4wV-ri-nxy" id="yNQ-hc-sdO"/>
@@ -279,6 +284,18 @@
     </scenes>
     <resources>
         <image name="MAxImage" width="16" height="16"/>
+        <image name="MAxImage" width="16" height="16"/>
         <image name="MinImage" width="16" height="16"/>
+        <image name="square.and.arrow.up" catalog="system" width="115" height="128"/>
+        <image name="square.and.arrow.up.on.square" catalog="system" width="117" height="128"/>
+        <systemColor name="systemOrangeColor">
+            <color red="1" green="0.58431372549019611" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemRedColor">
+            <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemTealColor">
+            <color red="0.35294117647058826" green="0.78431372549019607" blue="0.98039215686274506" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
     </resources>
 </document>


### PR DESCRIPTION
In #84 I make some search about new attributes

- uiswitch new attributes
- imagereferences

I create the `ImageReference` class but not decoded it yet because there is many way to do it

## Solution 1: split

When there is an attribute

```swift
var xxxImage: String?
```

we add a new property

```swift
var xxxImageReference: ImageReference?
```

*pro*: no compatibility issue
*cons*: must find one things in two vars, its. seems not very clean

## Solution 2: ImageReference is the way to go

have only one attribute

```swift
var xxxImage: ImageReference?
```

if we found a string, we create an instance of `ImageReference` with decoded string as name

*pro*: universal way to get info
*cons*: impossible to know how the image has beed decoded? by string or ref (and if a tool want to check that it could not) and compatibility change

## Solution 3 :  one protocol to rules them all

add a protocol `IBImage`(equatable) implemented by `String` and `ImageReference` (with an attribute imageName , stringiest return self, and imageReference return name)

so we have also one property

```swift
var xxxImage: IBImage?
```

*pro* : and we know if its based on string or imageReference
*cons*: if storyboard contains String and imageReference, yes that's an error, we could not detect it because when decoding we must choose one , and forgot the other (but we could throw an error maybe)

there is an update to do on dependencies because image are no more String, maybe a cast to string or get imageName

---

ps: I think a new version of ibdecodable must be created before merging this one, even if there is no compatibility change