### PR TITLE
Add support for adjustsFontForContentSizeCategory of the UILabel

### DIFF
--- a/Sources/Models/Views/Label.swift
+++ b/Sources/Models/Views/Label.swift
@@ -46,6 +46,7 @@ public struct Label: IBDecodable, ViewProtocol, IBIdentifiable {
     public let variations: [Variation]?
     public let backgroundColor: Color?
     public let tintColor: Color?
+    public let adjustsFontForContentSizeCategory: Bool?
 
     enum ConstraintsCodingKeys: CodingKey { case constraint }
     enum VariationCodingKey: CodingKey { case variation }
@@ -104,7 +105,8 @@ public struct Label: IBDecodable, ViewProtocol, IBIdentifiable {
             connections:                               container.childrenIfPresent(of: .connections),
             variations:                                variationContainer.elementsIfPresent(of: .variation),
             backgroundColor:                           colorsContainer?.withAttributeElement(.key, CodingKeys.backgroundColor.stringValue),
-            tintColor:                                 colorsContainer?.withAttributeElement(.key, CodingKeys.tintColor.stringValue)
+            tintColor:                                 colorsContainer?.withAttributeElement(.key, CodingKeys.tintColor.stringValue),
+            adjustsFontForContentSizeCategory:         container.attributeIfPresent(of: .adjustsFontForContentSizeCategory)
         )
     }
 

--- a/Tests/IBDecodableTests/Tests.swift
+++ b/Tests/IBDecodableTests/Tests.swift
@@ -446,6 +446,7 @@ class Tests: XCTestCase {
                 XCTFail("The label should have a textStyle type")
                 return
             }
+            XCTAssertEqual(labels.first?.adjustsFontForContentSizeCategory, .some(true), "adjustsFontForContentSizeCategory shpuld be true")
         } catch {
             XCTFail("\(error)  \(url)")
         }

--- a/Tests/Resources/LabelsWithFonts.xib
+++ b/Tests/Resources/LabelsWithFonts.xib
@@ -22,7 +22,7 @@
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="C4w-0I-Z9x">
                     <rect key="frame" x="165.5" y="303.5" width="44.5" height="60.5"/>
                     <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3fY-er-wyA">
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3fY-er-wyA">
                             <rect key="frame" x="0.0" y="0.0" width="44.5" height="20.5"/>
                             <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="17"/>
                             <nil key="textColor"/>


### PR DESCRIPTION
The `adjustsFontForContentSizeCategory` property is available in iOS 10.0+. The property is part of `UIContentSizeCategoryAdjusting` protocol and implemented by `UILabel`, `UITextField` and `UITextView` types. ([source](https://developer.apple.com/documentation/uikit/uicontentsizecategoryadjusting/1771731-adjustsfontforcontentsizecategor))

The property is part of Dynamic Type feature. The feature expects that a type sets the font property to style type and sets the adjustsFontForContentSizeCategory property to true.

iOS 10.0 was included in Xcode 8 ([source](https://en.wikipedia.org/wiki/Xcode#10.x_series))

![Capture d’écran 2020-10-11 à 11 09 15](https://user-images.githubusercontent.com/5544365/95674731-7b8f3880-0bb2-11eb-8f61-742bce5be406.png)

