### PR TITLE
Fix detecting systemColor on Xcode 11 or later

### DIFF
--- a/Sources/Models/Color.swift
+++ b/Sources/Models/Color.swift
@@ -48,6 +48,7 @@ public enum Color: IBDecodable {
     enum CodingKeys: CodingKey {
         case key
         case colorSpace
+        case systemColor
         case cocoaTouchSystemColor
     }
 
@@ -74,6 +75,11 @@ public enum Color: IBDecodable {
     static func decode(_ xml: XMLIndexerType) throws -> Color {
         let container = xml.container(keys: CodingKeys.self)
         let key: String? = container.attributeIfPresent(of: .key)
+
+        if let systemColor: String = container.attributeIfPresent(of: .systemColor) {
+            return .systemColor((key, systemColor))
+        }
+
         if let colorSpace: String = container.attributeIfPresent(of: .colorSpace) {
             switch colorSpace {
             case "calibratedWhite":

--- a/Tests/IBDecodableTests/Tests.swift
+++ b/Tests/IBDecodableTests/Tests.swift
@@ -489,6 +489,13 @@ class Tests: XCTestCase {
                 XCTAssertNotNil($0.backgroundColor)
                 XCTAssertNotNil($0.tintColor)
             }
+
+            let systemColorBackgroundView = views.first(where: { $0.userLabel == "View with System Color" })
+            if case .systemColor(let systemColor) = systemColorBackgroundView?.backgroundColor {
+                XCTAssertEqual(systemColor.name, "systemOrangeColor")
+            } else {
+                XCTFail()
+            }
         } catch {
             XCTFail("\(error)  \(url)")
         }

--- a/Tests/Resources/ViewsWithBackgroundColor.xib
+++ b/Tests/Resources/ViewsWithBackgroundColor.xib
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -19,11 +17,19 @@
             <viewLayoutGuide key="safeArea" id="X6C-YP-6rn"/>
             <point key="canvasLocation" x="84" y="76"/>
         </view>
+        <view contentMode="scaleToFill" id="Qov-nb-VBj" userLabel="View with System Color">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <color key="backgroundColor" systemColor="systemOrangeColor" red="1" green="0.58431372550000005" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color key="tintColor" red="0.97513258820000004" green="0.2546594116" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <viewLayoutGuide key="safeArea" id="kSd-IL-b0e"/>
+            <point key="canvasLocation" x="809" y="252"/>
+        </view>
         <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="jKS-5y-TBK">
             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="jKS-5y-TBK" id="Xq1-Ao-F1Q">
-                <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
             </tableViewCellContentView>
             <color key="backgroundColor" red="1" green="0.63078395700000001" blue="0.39357040630000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
In Xcode 11, XML of systemColor seems to be this.

```
<color key="backgroundColor" systemColor="systemOrangeColor" red="1" green="0.58431372550000005" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
```

In this XML, systemColor is treated as a custom color because it has a "custom" colorSpace.
https://github.com/IBDecodable/IBDecodable/blob/987d199a4a6a6963393cfd9125353e1596fbe5f7/Sources/Models/Color.swift#L92-L106


In Xcode 12, this is an XML example of systemColor.
```
<color key="backgroundColor" systemColor="systemOrangeColor" />
```
In this case, it is treated as systemColor with this patch.


I found this because the `stackview_backgroundcolor` rule of IBLinter does not work.
